### PR TITLE
"InputEngine is not defined" error in Qt5.5 fix

### DIFF
--- a/src/VirtualKeyboardInputContextPlugin.h
+++ b/src/VirtualKeyboardInputContextPlugin.h
@@ -22,7 +22,7 @@
 class VirtualKeyboardInputContextPlugin : public QPlatformInputContextPlugin
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QPlatformInputContextFactoryInterface" FILE "VirtualKeyboardInputContextPlugin.json")
+    Q_PLUGIN_METADATA(IID QPlatformInputContextFactoryInterface_iid FILE "VirtualKeyboardInputContextPlugin.json")
 
 public:
     QPlatformInputContext *create(const QString&, const QStringList&);


### PR DESCRIPTION
Errors due to changes in IID of the QPlatformInputContextFactoryInterface between Qt versions solved.