### PR TITLE
Ensure that focuse object is visible if flickable height changes.

### DIFF
--- a/src/VirtualKeyboardInputContext.cpp
+++ b/src/VirtualKeyboardInputContext.cpp
@@ -187,6 +187,8 @@ void VirtualKeyboardInputContext::setFocusObject(QObject *object)
         {
             d->Flickable = Flickable;
             qDebug() << "is QQuickFlickable";
+            connect(d->Flickable, &QQuickItem::heightChanged, this,
+                    &VirtualKeyboardInputContext::ensureFocusedObjectVisible);
         }
         i = i->parentItem();
     }


### PR DESCRIPTION
This improves usability when keyboard is loaded dynamically with a Loader.